### PR TITLE
fix: do not publish redis or db ports to the host.

### DIFF
--- a/config/discovery-db.container
+++ b/config/discovery-db.container
@@ -5,7 +5,6 @@ Requires=podman.socket
 [Container]
 ContainerName=discovery-db
 Image=registry.redhat.io/rhel8/postgresql-12:latest
-PublishPort=5432:5432
 ExposeHostPort=5432
 Environment=POSTGRESQL_USER=qpc
 Environment=POSTGRESQL_PASSWORD=qpc

--- a/config/discovery-redis.container
+++ b/config/discovery-redis.container
@@ -5,7 +5,6 @@ Requires=podman.socket
 [Container]
 ContainerName=discovery-redis
 Image=registry.redhat.io/rhel9/redis-6:latest
-PublishPort=6379:6379
 ExposeHostPort=6379
 EnvironmentFile=%h/.config/discovery/env/env-redis.env
 Network=discovery.network

--- a/config/env-redis.env
+++ b/config/env-redis.env
@@ -1,2 +1,3 @@
 REDIS_HOST=discovery-redis
+REDIS_PORT=6379
 REDIS_PASSWORD=qpc


### PR DESCRIPTION
- Redis and Db do not need to be published to the host, they are accessed within the discovery network just fine.

