### PR TITLE
chore(app): Need to use the v2-alpha ui container/

### DIFF
--- a/config/discovery-app.container
+++ b/config/discovery-app.container
@@ -9,7 +9,7 @@ After=discovery-server.service
 
 [Container]
 ContainerName=discovery-app
-Image=quay.io/quipucords/quipucords-ui:latest
+Image=quay.io/quipucords/quipucords-ui:v2-alpha
 PublishPort=9443:9443
 ExposeHostPort=9443
 EnvironmentFile=%h/.config/discovery/env/env-app.env


### PR DESCRIPTION
- Until the v2-alpha UI container moves to latest, we need to pull in that tag as the default. Logic pertaining to nginx logging and such is required.