### PR TITLE
fix(celery-worker): Should mount the /sshkeys just like the server

### DIFF
--- a/config/discovery-celery-worker.container
+++ b/config/discovery-celery-worker.container
@@ -15,6 +15,7 @@ Secret=discovery-django-secret-key,type=env,target=DJANGO_SECRET_KEY
 Exec=/bin/sh -c /deploy/entrypoint_celery_worker.sh
 Volume=%h/.local/share/discovery/data:/var/data:z
 Volume=%h/.local/share/discovery/log:/var/log:z
+Volume=%h/.local/share/discovery/sshkeys:/sshkeys:z
 Network=discovery.network
 
 [Service]


### PR DESCRIPTION
- Celery worker should be mounting the /sshkeys just like the server as tasks would require that if configured to authenticate as such.