### PR TITLE
fix: Allow backend and Celery worker to share cached_reports dir

### DIFF
--- a/config/discovery-celery-worker.container
+++ b/config/discovery-celery-worker.container
@@ -16,6 +16,7 @@ Exec=/bin/sh -c /deploy/entrypoint_celery_worker.sh
 Volume=%h/.local/share/discovery/data:/var/data:z
 Volume=%h/.local/share/discovery/log:/var/log:z
 Volume=%h/.local/share/discovery/sshkeys:/sshkeys:z
+Volume=discovery-cached-reports:/app/var/cached_reports:z
 Network=discovery.network
 
 [Service]

--- a/config/discovery-server.container
+++ b/config/discovery-server.container
@@ -18,6 +18,7 @@ Secret=discovery-django-secret-key,type=env,target=DJANGO_SECRET_KEY
 Volume=%h/.local/share/discovery/data:/var/data:z
 Volume=%h/.local/share/discovery/log:/var/log:z
 Volume=%h/.local/share/discovery/sshkeys:/sshkeys:z
+Volume=discovery-cached-reports:/app/var/cached_reports:z
 Network=discovery.network
 
 [Service]


### PR DESCRIPTION
Since quipucords PR#2681, some report files are being cached in local filesystem. However, the directory was not being shared by backend and Celery workers, which resulted in backend sending wrong data when reports were requested.

This PR introduces named volume to allow data sharing between instances. Named volumes are created automatically by Podman and survive container stopping and removal. Which means we don't have to create them manually in `bin/discovery-installer`.

This resolves DISCOVERY-699