### PR TITLE
Revert "fix: Allow backend and Celery worker to share cached_reports dir"

### DIFF
--- a/config/discovery-celery-worker.container
+++ b/config/discovery-celery-worker.container
@@ -16,7 +16,6 @@ Exec=/bin/sh -c /deploy/entrypoint_celery_worker.sh
 Volume=%h/.local/share/discovery/data:/var/data:z
 Volume=%h/.local/share/discovery/log:/var/log:z
 Volume=%h/.local/share/discovery/sshkeys:/sshkeys:z
-Volume=discovery-cached-reports:/app/var/cached_reports:z
 Network=discovery.network
 
 [Service]

--- a/config/discovery-server.container
+++ b/config/discovery-server.container
@@ -18,7 +18,6 @@ Secret=discovery-django-secret-key,type=env,target=DJANGO_SECRET_KEY
 Volume=%h/.local/share/discovery/data:/var/data:z
 Volume=%h/.local/share/discovery/log:/var/log:z
 Volume=%h/.local/share/discovery/sshkeys:/sshkeys:z
-Volume=discovery-cached-reports:/app/var/cached_reports:z
 Network=discovery.network
 
 [Service]


### PR DESCRIPTION
This reverts commit 3c234c4542d0f43106e4e439f408e768fa54b999 (PR #12 )

It is no longer needed since https://github.com/quipucords/quipucords/pull/2690