### PR TITLE
chore: contain db files to a specific subfolder

### DIFF
--- a/bin/discovery-installer
+++ b/bin/discovery-installer
@@ -193,6 +193,7 @@ if [ "${COMMAND}" == "install" ]; then
   fi
 
   mkdir -p "${DISCOVERY_USER_PATH}/data"
+  mkdir -p "${DISCOVERY_USER_PATH}/db"
   mkdir -p "${DISCOVERY_USER_PATH}/log"
   mkdir -p "${DISCOVERY_USER_PATH}/sshkeys"
   mkdir -p "${DISCOVERY_USER_PATH}/certs"

--- a/config/discovery-db.container
+++ b/config/discovery-db.container
@@ -10,7 +10,7 @@ ExposeHostPort=5432
 Environment=POSTGRESQL_USER=qpc
 Environment=POSTGRESQL_PASSWORD=qpc
 Environment=POSTGRESQL_DATABASE=qpc
-Volume=%h/.local/share/discovery/data:/var/lib/pgsql/data:z
+Volume=%h/.local/share/discovery/db:/var/lib/pgsql/data:z
 Network=discovery.network
 # for some reason podman default user mapping won't map host user to postgres container uid (26)[1]
 # (maybe due to fix-permission script it executes later on [2]), so we fix that setting this up with


### PR DESCRIPTION
Considering discovery is using data folder as a generic place for many internal files, scoping postgres files to a specific subfolder seems wise.